### PR TITLE
Fix Python version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Glimmer Utils
 
+[![PyPI version](https://img.shields.io/pypi/v/glimmer.svg)](https://pypi.org/project/glimmer/) [![Python versions](https://img.shields.io/badge/python-%3E%3D3.8-blue)](https://pypi.org/project/glimmer/) [![License](https://img.shields.io/github/license/immanuelweber/glimmer-utils.svg)](LICENSE)
+
 Utilities for working with [PyTorch](https://pytorch.org/) and [PyTorch Lightning](https://www.pytorchlightning.ai/).
 
 ## Features


### PR DESCRIPTION
## Summary
- refine README badges so Python version clearly shows >=3.8

## Testing
- `PYTHONPATH=$PWD pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6845c928ec2c8322b516506db745ff32