### PR TITLE
Add safe fallback for package version

### DIFF
--- a/glimmer/__init__.py
+++ b/glimmer/__init__.py
@@ -4,7 +4,11 @@ try:
     from ._version import __version__
 except ImportError:
     # Fallback for development installs
-    from importlib.metadata import version
-    __version__ = version("glimmer")
+    from importlib.metadata import PackageNotFoundError, version
+
+    try:
+        __version__ = version("glimmer")
+    except PackageNotFoundError:
+        __version__ = "0.0.0"
 
 __all__ = ["data", "lightning", "__version__"]


### PR DESCRIPTION
## Summary
- handle missing `_version` file when running from source
- default to version "0.0.0" if the package metadata is unavailable

## Testing
- `PYTHONPATH=. pytest -q`
- `python -m compileall -q glimmer`


------
https://chatgpt.com/codex/tasks/task_e_68515d2986488322ad7c35fcfb4d65b5